### PR TITLE
Update TALA seed command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ impact on the overall layout, as it may converge on an entirely different one.
 For advanced usage of TALA, you may specify the seed to get a different layout:
 
 ```d2
-d2 --layout tala --tala-seed 44 input.d2
+d2 --layout tala --tala-seeds 44 input.d2
 ```
 
 ### Add API token (optional)


### PR DESCRIPTION
Had some issues trying to use the TALA seed command with one of the newer versions of the D2 CLI. Discovered through the user manual that the flag for that changed from --tala-seed to --tala-seeds. This PR updates the README.md to reflect this change.